### PR TITLE
NOJIRA : Ability to use environment and system properties in config

### DIFF
--- a/src/main/java/in/ashwanthkumar/gocd/artifacts/config/JanitorConfiguration.java
+++ b/src/main/java/in/ashwanthkumar/gocd/artifacts/config/JanitorConfiguration.java
@@ -27,6 +27,9 @@ public class JanitorConfiguration {
     }
 
     public static JanitorConfiguration load(Config config) {
+        Config envThenSystem = ConfigFactory.systemEnvironment().withFallback(ConfigFactory.systemProperties());
+        config = config.resolveWith(envThenSystem);
+
         config = config.getConfig("gocd.janitor");
 
         final JanitorConfiguration janitorConfiguration = new JanitorConfiguration()

--- a/src/test/java/in/ashwanthkumar/gocd/artifacts/config/JanitorConfigurationTest.java
+++ b/src/test/java/in/ashwanthkumar/gocd/artifacts/config/JanitorConfigurationTest.java
@@ -3,7 +3,10 @@ package in.ashwanthkumar.gocd.artifacts.config;
 import in.ashwanthkumar.gocd.client.TestUtils;
 import org.junit.Test;
 
+import java.util.UUID;
+
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.core.IsCollectionContaining.hasItem;
 import static org.junit.Assert.*;
 
@@ -42,4 +45,25 @@ public class JanitorConfigurationTest {
         assertThat(configuration.getPipelines(), hasItem(expected2));
     }
 
+    @Test
+    public void shouldLoadTestConfigWithSystemProperties() {
+        System.setProperty("HOME", UUID.randomUUID().toString());
+        System.setProperty("GO_PASSWORD","letmein");
+
+        assertThat(System.getenv("HOME"),not(System.getProperty("HOME")));
+
+        JanitorConfiguration configuration = JanitorConfiguration.load(TestUtils.fileName("/test-config-withproperties.conf"));
+        assertThat(configuration.getServer(), is("http://localhost"));
+        assertThat(configuration.getArtifactStorage(), is("/data/go-server/artifacts/"));
+        assertThat(configuration.getUsername(), is(System.getenv("HOME")));
+        assertThat(configuration.getPassword(), is(System.getProperty("GO_PASSWORD")));
+        assertThat(configuration.getDefaultPipelineVersions(), is(5));
+        assertThat(configuration.getPipelinePrefix(), is(""));
+
+        PipelineConfig expected1 = new PipelineConfig("Pipeline1", 2);
+        assertThat(configuration.getPipelines(), hasItem(expected1));
+
+        PipelineConfig expected2 = new PipelineConfig("Pipeline2", 5);
+        assertThat(configuration.getPipelines(), hasItem(expected2));
+    }
 }

--- a/src/test/resources/test-config-withproperties.conf
+++ b/src/test/resources/test-config-withproperties.conf
@@ -1,0 +1,18 @@
+gocd.janitor {
+  server = "http://localhost"
+  username = ${HOME}
+  password = ${GO_PASSWORD}
+  artifacts-dir = "/data/go-server/artifacts/"
+  pipeline-versions = 5
+
+  pipelines = [{
+    name = "Pipeline1"
+    # Number of successful runs of this pipeline and all its dependents you want to keep
+    # Checkout README for how we classify a successful pipeline run
+    # This number can't be greater than PipelineConfig.MAX_RUN_LIMIT (5)
+    runs = 2
+  }, {
+    name = "Pipeline2"
+    runs = 5
+  }]
+}


### PR DESCRIPTION
Hi there,

TLDR;  Allow the use of environment variable or system properties within the .config file. 

There might be another way to do this, as my experience with the type space config isn't too great, but I couldn't figure out any other way.

I wish to be able to pull the GOCD username and password from the environment, rather than committing the username and password into the configuration file.  For example:

```
gocd.janitor {
  server = "http://localhost:8153"
  username = ${GOCD_USERNAME}
  password = ${GOCD_PASSWORD}
  ....
```

The username and password for gocd can than be sourced at runtime.  This could extend to other values in the configuration too.  However, for our purposes, the username and password is the require fields to be sourced from the environment.

The pull request has the environment taking precedence over system properties (i.e. operator override).

Hope that makes sense.
Thanks
/dom
